### PR TITLE
Fix zookeeper example to use valid JSON in README

### DIFF
--- a/example/flavor/zookeeper/README.md
+++ b/example/flavor/zookeeper/README.md
@@ -85,7 +85,7 @@ Here's a JSON for the group we'd like to see [vagrant-zk-example.json](./vagrant
             "Properties": {
                 "Box": "bento/ubuntu-16.04"
             }
-        }
+        },
         "Flavor" : {
             "Plugin": "flavor-zookeeper",
             "Properties": {


### PR DESCRIPTION
This was fixed in https://github.com/docker/infrakit/pull/197 but only in the accompanying JSON file, not in the README.
